### PR TITLE
feat: add serializers, viewsets, and routing for Server and Device models

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+from .views import DeviceViewSet, ServerViewSet
+
+router = DefaultRouter()
+router.register(r'devices', DeviceViewSet, basename='device')
+router.register(r'servers', ServerViewSet, basename='server')
+
+urlpatterns = router.urls

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,29 @@
-from django.shortcuts import render
+from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
+from api.serializers import DeviceSerializer, ServerSerializer
+from api.models import Device, Server
 
-# Create your views here.
+class DeviceViewSet(viewsets.ModelViewSet):
+    '''
+    POST /api/devices/ - Register a device
+    GET /api/devices/ - List devices
+    PATCH /api/devices/{id} - Update a device's status
+    '''
+    queryset = Device.objects.all().order_by('id')
+    serializer_class = DeviceSerializer
+    permission_classes = [AllowAny]
+    http_method_names = ['get', 'post', 'patch']
+
+
+
+class ServerViewSet(viewsets.ModelViewSet):
+    '''
+    POST /api/servers/ - Create a new server
+    GET /api/servers/ - List all servers
+    GET /api/servers/{id} - Get a specific server's details
+    PATCH /api/servers/{id} - Update a specific server's status
+    '''
+    queryset = Server.objects.select_related('device').order_by('id')
+    serializer_class = ServerSerializer
+    permission_classes = [AllowAny]
+    http_method_names = ['get', 'post', 'patch']

--- a/servermanager/urls.py
+++ b/servermanager/urls.py
@@ -21,9 +21,9 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    # path('', include('api.urls')),
+    path('api/', include('api.urls')),
 
     # Spectacular
-    # path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
-    # path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]


### PR DESCRIPTION
Implemented serializers, viewsets, and URL routing for Server and Device models.

- Added DeviceSerializer with read-only last_seen
- Added ServerSerializer with name validation and read-only fields (subdomain, created_at)
- Created DeviceViewSet and ServerViewSet using ModelViewSet
- Configured router in api/urls.py to expose endpoints
- Ensured default server status is "stopped" via model default

Closes #3 